### PR TITLE
Mc 1.7 -- tweaks log and wood

### DIFF
--- a/src/main/java/net/einsteinsci/betterbeginnings/ModMain.java
+++ b/src/main/java/net/einsteinsci/betterbeginnings/ModMain.java
@@ -22,6 +22,8 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Configuration;
 import org.apache.logging.log4j.Level;
 
+import net.einsteinsci.betterbeginnings.gggh.tweaks.Tweaks;
+
 @Mod(modid = ModMain.MODID, version = ModMain.VERSION, name = ModMain.NAME,
      guiFactory = "net.einsteinsci.betterbeginnings.config.BBConfigGuiFactory")
 public class ModMain

--- a/src/main/java/net/einsteinsci/betterbeginnings/ModMain.java
+++ b/src/main/java/net/einsteinsci/betterbeginnings/ModMain.java
@@ -110,6 +110,8 @@ public class ModMain
 		RegisterRecipes.addFurnaceRecipes();
 
 		RemoveRecipes.removeFurnaceRecipes();
+		
+		Tweaks.apply(); //see package ...gggh.tweaks
 	}
 
 	@EventHandler

--- a/src/main/java/net/einsteinsci/betterbeginnings/ModMain.java
+++ b/src/main/java/net/einsteinsci/betterbeginnings/ModMain.java
@@ -113,7 +113,7 @@ public class ModMain
 
 		RemoveRecipes.removeFurnaceRecipes();
 		
-		Tweaks.apply(); //see package ...gggh.tweaks
+		Tweaks.doTweaks(); //see package ...gggh.tweaks
 	}
 
 	@EventHandler

--- a/src/main/java/net/einsteinsci/betterbeginnings/ModMain.java
+++ b/src/main/java/net/einsteinsci/betterbeginnings/ModMain.java
@@ -95,6 +95,9 @@ public class ModMain
 		RegisterItems.register();
 		RegisterBlocks.register();
 		RegisterTileEntities.register();
+		
+		Tweaks.applyForLogs();// see ... gggh.tweaks
+		Tweaks.applyForWood();
 	}
 
 	public static void Log(String text)
@@ -113,7 +116,7 @@ public class ModMain
 
 		RemoveRecipes.removeFurnaceRecipes();
 		
-		Tweaks.doTweaks(); //see package ...gggh.tweaks
+		
 	}
 
 	@EventHandler

--- a/src/main/java/net/einsteinsci/betterbeginnings/event/BBEventHandler.java
+++ b/src/main/java/net/einsteinsci/betterbeginnings/event/BBEventHandler.java
@@ -194,7 +194,7 @@ public class BBEventHandler
 
 		if (!correctTool)
 		{
-			e.setCanceled(true);
+			//e.setCanceled(true); //no need to cancel (see package ...gggh.tweaks)
 			if (usedFace)
 			{
 				// What do you think the player's 'durability' is?

--- a/src/main/java/net/einsteinsci/betterbeginnings/gggh/tweaks
+++ b/src/main/java/net/einsteinsci/betterbeginnings/gggh/tweaks
@@ -1,61 +1,67 @@
 package net.einsteinsci.betterbeginnings.gggh.tweaks;
 
-import java.lang.reflect.Method;
-
-import com.google.common.reflect.Reflection;
-
-import net.minecraft.block.material.Material;
+import cpw.mods.fml.common.ObfuscationReflectionHelper;
+import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
-import net.minecraftforge.common.ForgeHooks;
-import cpw.mods.fml.relauncher.ReflectionHelper;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+ 
 
-// Yes!! I've found it ! Well ... I've found this:
-//see http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-mods/modification-development/1432809-forge-solved-destroying-vanilla-blocks-without
-public class Tweaks {
-	public static void doTweaks(){
-		apply();
-		repair();
+
+
+import java.util.ArrayList;
+ 
+public class Tweaks { 	//copied from: https://gist.github.com/Choonster/c9a50945f6f83398328b 
+						//
+ 
+	public static MaterialUnpunchableLogs materialUnpunchableLogs = new MaterialUnpunchableLogs(); 
+	
+	public static void applyForLogs() { 
+		ArrayList<ItemStack> logItemStacks = OreDictionary.getOres("logWood"); // Get a list of ItemStacks registered for "logWood"
+		for (ItemStack logItemStack : logItemStacks) { // For each ItemStack,
+			Block logBlock = Block.getBlockFromItem(logItemStack.getItem()); // Get the ItemStack's Block
+			if (logBlock != null && logBlock.getMaterial() != materialUnpunchableLogs) { // If the Block exists and doesn't have the custom Material
+				ObfuscationReflectionHelper.setPrivateValue(Block.class, logBlock, materialUnpunchableLogs, "blockMaterial", "field_149764_J"); // Set the Block's Material to the custom Material
+			
+			}
+		}
+	}
+	// addapted for planks
+	public static void applyForWood(){
+		ArrayList<ItemStack> WoodItemStacks = OreDictionary.getOres("plankWood");
+		for (ItemStack woodStack : WoodItemStacks) { 
+			Block woodBlock = Block.getBlockFromItem(woodStack.getItem()); 
+			if (woodBlock != null && woodBlock.getMaterial() != materialUnpunchableLogs) { 
+				ObfuscationReflectionHelper.setPrivateValue(Block.class, woodBlock, materialUnpunchableLogs, "blockMaterial", "field_149764_J");
+				
+			}
+		}
 	}
 	
-	private static void apply(){
-	    try {
-	    	Method m = ReflectionHelper.findMethod(Material.class, Material.wood, new String[] {"func_76221_f", "setRequiresTool"});
-		    m.invoke(Material.wood);
-	    } catch (Throwable t) {
-		    System.out.println("Couldn't find method setRequiresTool");
-		    System.out.println("Methods in Material:");
-		    for (Method method : Material.class.getDeclaredMethods())
-			    System.out.println(" " + method.getName());
-	    }
+	// addapted for various wooden blocks
+		// --> it seems that even with a axe we can't mine them 
+	public static void applyForWoodStuff(){
+		ArrayList<Block> stuff = new ArrayList<Block>();
+		
+		stuff.add(Blocks.fence);
+		stuff.add(Blocks.fence_gate);
+		stuff.add(Blocks.wooden_slab);
+		//stuff.add(Blocks.wooden_door);
+		stuff.add(Blocks.oak_stairs);
+		stuff.add(Blocks.spruce_stairs);
+		stuff.add(Blocks.birch_stairs);
+		stuff.add(Blocks.jungle_stairs);
+		stuff.add(Blocks.acacia_stairs);
+		stuff.add(Blocks.dark_oak_stairs);
+//!!!	//to add manualy: stairs from other mods (eventualy in config)
+		
+		for (Block block: stuff){
+			if (block != null && block.getMaterial() != materialUnpunchableLogs) { 
+				ObfuscationReflectionHelper.setPrivateValue(Block.class, block, materialUnpunchableLogs, "blockMaterial", "field_149764_J");
+			}
+		}
 	}
-	private static void repair(){ //repair things that don't drop anymore
-		
-		Reflection.initialize(ForgeHooks.class);
-		
-		Blocks.wooden_slab.setHarvestLevel("axe", 0);
-		Blocks.wooden_door.setHarvestLevel("axe", 0);
-		
-		Blocks.fence.setHarvestLevel("axe", 0);
-		Blocks.fence_gate.setHarvestLevel("axe", 0);
-		
-		//don't know for signs
-		//repairSigns();
-		
-		
-		Blocks.oak_stairs.setHarvestLevel("axe", 0);
-		Blocks.spruce_stairs.setHarvestLevel("axe", 0);
-		Blocks.birch_stairs.setHarvestLevel("axe", 0);
-		Blocks.jungle_stairs.setHarvestLevel("axe", 0);
-		Blocks.acacia_stairs.setHarvestLevel("axe", 0);
-		Blocks.dark_oak_stairs.setHarvestLevel("axe", 0);
-	}
-	/*
-	private static void repairSigns(){
-				//something with reflection(???), or with events :/
-	    }
-	*/
+	
+	
 }
-		
-		
 	
-

--- a/src/main/java/net/einsteinsci/betterbeginnings/gggh/tweaks
+++ b/src/main/java/net/einsteinsci/betterbeginnings/gggh/tweaks
@@ -1,0 +1,25 @@
+package net.einsteinsci.betterbeginnings.gggh.tweaks;
+
+import java.lang.reflect.Method;
+
+import net.minecraft.block.material.Material;
+import cpw.mods.fml.relauncher.ReflectionHelper;
+
+// Yes!! I've found it ! Well ... I've found this: (copied from:)
+//http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-mods/modification-development/1432809-forge-solved-destroying-vanilla-blocks-without
+public class Tweaks {
+	
+	public static void apply(){
+	    try {
+	    	Method m = ReflectionHelper.findMethod(Material.class, Material.wood, new String[] {"func_76221_f", "setRequiresTool"});
+		    m.invoke(Material.wood);
+	    } catch (Throwable t) {
+		    System.out.println("Couldn't find method setRequiresTool");
+		    System.out.println("Methods in Material:");
+		    for (Method method : Material.class.getDeclaredMethods())
+			    System.out.println(" " + method.getName());
+	    }
+	}
+	
+	
+}

--- a/src/main/java/net/einsteinsci/betterbeginnings/gggh/tweaks
+++ b/src/main/java/net/einsteinsci/betterbeginnings/gggh/tweaks
@@ -12,8 +12,7 @@ import net.minecraftforge.oredict.OreDictionary;
 import java.util.ArrayList;
  
 public class Tweaks { 	//copied from: https://gist.github.com/Choonster/c9a50945f6f83398328b 
-						//
- 
+						
 	public static MaterialUnpunchableLogs materialUnpunchableLogs = new MaterialUnpunchableLogs(); 
 	
 	public static void applyForLogs() { 
@@ -39,7 +38,9 @@ public class Tweaks { 	//copied from: https://gist.github.com/Choonster/c9a50945
 	}
 	
 	// addapted for various wooden blocks
-		// --> it seems that even with a axe we can't mine them 
+		// do not add this to the game
+		// --> it seems that even with an axe we can't mine them 
+		
 	public static void applyForWoodStuff(){
 		ArrayList<Block> stuff = new ArrayList<Block>();
 		
@@ -53,7 +54,7 @@ public class Tweaks { 	//copied from: https://gist.github.com/Choonster/c9a50945
 		stuff.add(Blocks.jungle_stairs);
 		stuff.add(Blocks.acacia_stairs);
 		stuff.add(Blocks.dark_oak_stairs);
-//!!!	//to add manualy: stairs from other mods (eventualy in config)
+	//to add manualy: stairs from other mods (eventualy in config)  --> don't work anyway :/
 		
 		for (Block block: stuff){
 			if (block != null && block.getMaterial() != materialUnpunchableLogs) { 

--- a/src/main/java/net/einsteinsci/betterbeginnings/gggh/tweaks
+++ b/src/main/java/net/einsteinsci/betterbeginnings/gggh/tweaks
@@ -2,17 +2,25 @@ package net.einsteinsci.betterbeginnings.gggh.tweaks;
 
 import java.lang.reflect.Method;
 
+import com.google.common.reflect.Reflection;
+
 import net.minecraft.block.material.Material;
+import net.minecraft.init.Blocks;
+import net.minecraftforge.common.ForgeHooks;
 import cpw.mods.fml.relauncher.ReflectionHelper;
 
-// Yes!! I've found it ! Well ... I've found this: (copied from:)
-//http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-mods/modification-development/1432809-forge-solved-destroying-vanilla-blocks-without
+// Yes!! I've found it ! Well ... I've found this:
+//see http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-mods/modification-development/1432809-forge-solved-destroying-vanilla-blocks-without
 public class Tweaks {
+	public static void doTweaks(){
+		apply();
+		repair();
+	}
 	
-	public static void apply(){
+	private static void apply(){
 	    try {
 	    	Method m = ReflectionHelper.findMethod(Material.class, Material.wood, new String[] {"func_76221_f", "setRequiresTool"});
-		    m.invoke(Material.wood); //'Material.wood' requires a tool now
+		    m.invoke(Material.wood);
 	    } catch (Throwable t) {
 		    System.out.println("Couldn't find method setRequiresTool");
 		    System.out.println("Methods in Material:");
@@ -20,6 +28,34 @@ public class Tweaks {
 			    System.out.println(" " + method.getName());
 	    }
 	}
-	
-	
+	private static void repair(){ //repair things that don't drop anymore
+		
+		Reflection.initialize(ForgeHooks.class);
+		
+		Blocks.wooden_slab.setHarvestLevel("axe", 0);
+		Blocks.wooden_door.setHarvestLevel("axe", 0);
+		
+		Blocks.fence.setHarvestLevel("axe", 0);
+		Blocks.fence_gate.setHarvestLevel("axe", 0);
+		
+		//don't know for signs
+		//repairSigns();
+		
+		
+		Blocks.oak_stairs.setHarvestLevel("axe", 0);
+		Blocks.spruce_stairs.setHarvestLevel("axe", 0);
+		Blocks.birch_stairs.setHarvestLevel("axe", 0);
+		Blocks.jungle_stairs.setHarvestLevel("axe", 0);
+		Blocks.acacia_stairs.setHarvestLevel("axe", 0);
+		Blocks.dark_oak_stairs.setHarvestLevel("axe", 0);
+	}
+	/*
+	private static void repairSigns(){
+				//something with reflection(???), or with events :/
+	    }
+	*/
 }
+		
+		
+	
+

--- a/src/main/java/net/einsteinsci/betterbeginnings/gggh/tweaks
+++ b/src/main/java/net/einsteinsci/betterbeginnings/gggh/tweaks
@@ -12,7 +12,7 @@ public class Tweaks {
 	public static void apply(){
 	    try {
 	    	Method m = ReflectionHelper.findMethod(Material.class, Material.wood, new String[] {"func_76221_f", "setRequiresTool"});
-		    m.invoke(Material.wood);
+		    m.invoke(Material.wood); //'Material.wood' requires a tool now
 	    } catch (Throwable t) {
 		    System.out.println("Couldn't find method setRequiresTool");
 		    System.out.println("Methods in Material:");


### PR DESCRIPTION
Mining logs and wood planks requires now an axe (without cancellations events).
They are still 'breakable' but don't drop when 'punched' (like vanilla: punching cobble).

- Was this the aim of the 'cancel' events ?




