### PR TITLE
Fixes #99, tags sync custom names

### DIFF
--- a/src/main/java/net/einsteinsci/betterbeginnings/tileentity/TileEntityBrickOven.java
+++ b/src/main/java/net/einsteinsci/betterbeginnings/tileentity/TileEntityBrickOven.java
@@ -15,6 +15,9 @@ import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.*;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.Packet;
+import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.server.gui.IUpdatePlayerListBox;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.*;
@@ -483,5 +486,19 @@ public class TileEntityBrickOven extends TileEntity implements ISidedInventory, 
 	public String getGuiID()
 	{
 		return ModMain.MODID + ":brickOven";
+	}
+	
+	@Override
+	public Packet getDescriptionPacket()
+	{
+		NBTTagCompound tag = new NBTTagCompound();
+		writeToNBT(tag);
+		return new S35PacketUpdateTileEntity(pos, 1, tag);
+	}
+	
+	@Override
+	public void onDataPacket(NetworkManager manager, S35PacketUpdateTileEntity packet)
+	{
+		readFromNBT(packet.getNbtCompound());
 	}
 }

--- a/src/main/java/net/einsteinsci/betterbeginnings/tileentity/TileEntityCampfire.java
+++ b/src/main/java/net/einsteinsci/betterbeginnings/tileentity/TileEntityCampfire.java
@@ -19,6 +19,9 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.*;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.Packet;
+import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.server.gui.IUpdatePlayerListBox;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.*;
@@ -628,5 +631,19 @@ public class TileEntityCampfire extends TileEntity implements IInventory, IUpdat
 	public String getGuiID()
 	{
 		return ModMain.MODID + ":campfire";
+	}
+	
+	@Override
+	public Packet getDescriptionPacket()
+	{
+		NBTTagCompound tag = new NBTTagCompound();
+		writeToNBT(tag);
+		return new S35PacketUpdateTileEntity(pos, 1, tag);
+	}
+	
+	@Override
+	public void onDataPacket(NetworkManager manager, S35PacketUpdateTileEntity packet)
+	{
+		readFromNBT(packet.getNbtCompound());
 	}
 }

--- a/src/main/java/net/einsteinsci/betterbeginnings/tileentity/TileEntityEnderSmelter.java
+++ b/src/main/java/net/einsteinsci/betterbeginnings/tileentity/TileEntityEnderSmelter.java
@@ -14,6 +14,9 @@ import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.*;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.Packet;
+import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.server.gui.IUpdatePlayerListBox;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.*;
@@ -538,7 +541,19 @@ public class TileEntityEnderSmelter extends TileEntity implements IUpdatePlayerL
 		return ModMain.MODID + ":enderSmelter";
 	}
 
-
+	@Override
+	public Packet getDescriptionPacket()
+	{
+		NBTTagCompound tag = new NBTTagCompound();
+		writeToNBT(tag);
+		return new S35PacketUpdateTileEntity(pos, 1, tag);
+	}
+	
+	@Override
+	public void onDataPacket(NetworkManager manager, S35PacketUpdateTileEntity packet)
+	{
+		readFromNBT(packet.getNbtCompound());
+	}
 
 
 

--- a/src/main/java/net/einsteinsci/betterbeginnings/tileentity/TileEntityKiln.java
+++ b/src/main/java/net/einsteinsci/betterbeginnings/tileentity/TileEntityKiln.java
@@ -16,6 +16,9 @@ import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.*;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.Packet;
+import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.server.gui.IUpdatePlayerListBox;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.*;
@@ -525,4 +528,18 @@ public class TileEntityKiln extends TileEntity implements IUpdatePlayerListBox, 
 	}
 
 
+	@Override
+	public Packet getDescriptionPacket()
+	{
+		NBTTagCompound tag = new NBTTagCompound();
+		writeToNBT(tag);
+		return new S35PacketUpdateTileEntity(pos, 1, tag);
+	}
+	
+	@Override
+	public void onDataPacket(NetworkManager manager, S35PacketUpdateTileEntity packet)
+	{
+		readFromNBT(packet.getNbtCompound());
+	}
+	
 }

--- a/src/main/java/net/einsteinsci/betterbeginnings/tileentity/TileEntityObsidianKiln.java
+++ b/src/main/java/net/einsteinsci/betterbeginnings/tileentity/TileEntityObsidianKiln.java
@@ -15,6 +15,9 @@ import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.*;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.Packet;
+import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.server.gui.IUpdatePlayerListBox;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.*;
@@ -458,7 +461,19 @@ public class TileEntityObsidianKiln extends TileEntity implements IUpdatePlayerL
 		return ModMain.MODID + ":obsidianKiln";
 	}
 
-
+	@Override
+	public Packet getDescriptionPacket()
+	{
+		NBTTagCompound tag = new NBTTagCompound();
+		writeToNBT(tag);
+		return new S35PacketUpdateTileEntity(pos, 1, tag);
+	}
+	
+	@Override
+	public void onDataPacket(NetworkManager manager, S35PacketUpdateTileEntity packet)
+	{
+		readFromNBT(packet.getNbtCompound());
+	}
 
 
 

--- a/src/main/java/net/einsteinsci/betterbeginnings/tileentity/TileEntitySmelter.java
+++ b/src/main/java/net/einsteinsci/betterbeginnings/tileentity/TileEntitySmelter.java
@@ -12,6 +12,9 @@ import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.*;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.Packet;
+import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.server.gui.IUpdatePlayerListBox;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.*;
@@ -484,5 +487,19 @@ public class TileEntitySmelter extends TileEntity implements ISidedInventory, IU
 	public String getGuiID()
 	{
 		return null;
+	}
+
+	@Override
+	public Packet getDescriptionPacket()
+	{
+		NBTTagCompound tag = new NBTTagCompound();
+		writeToNBT(tag);
+		return new S35PacketUpdateTileEntity(pos, 1, tag);
+	}
+	
+	@Override
+	public void onDataPacket(NetworkManager manager, S35PacketUpdateTileEntity packet)
+	{
+		readFromNBT(packet.getNbtCompound());
 	}
 }


### PR DESCRIPTION
Adding packet functions from TileEntityNetherBrickOven to other TEs makes custom names sync properly. The names themselves appear to save properly so any previously set custom names should show up properly now.