### PR TITLE
More intuitive catalyst display

### DIFF
--- a/src/main/java/net/einsteinsci/betterbeginnings/gui/GuiDoubleWorkbench.java
+++ b/src/main/java/net/einsteinsci/betterbeginnings/gui/GuiDoubleWorkbench.java
@@ -184,7 +184,8 @@ public class GuiDoubleWorkbench extends GuiContainer
 						if (matStack == null || matStack.stackSize < needed.stackSize)
 						{
 							drawItemStack(needed, k + slot.xDisplayPosition + CATALYST_X_OFFSET,
-								l + slot.yDisplayPosition, "" + (matStack == null ? needed.stackSize : needed.stackSize - matStack.stackSize));
+								l + slot.yDisplayPosition,
+								"" + (matStack == null ? needed.stackSize : needed.stackSize - matStack.stackSize));
 						}
 					}
 

--- a/src/main/java/net/einsteinsci/betterbeginnings/gui/GuiDoubleWorkbench.java
+++ b/src/main/java/net/einsteinsci/betterbeginnings/gui/GuiDoubleWorkbench.java
@@ -180,10 +180,11 @@ public class GuiDoubleWorkbench extends GuiContainer
 						}
 
 						Slot slot = container.matSlots[i];
-						if (container.addedMats.getStackInSlot(i) == null)
+						ItemStack matStack = container.addedMats.getStackInSlot(i);
+						if (matStack == null || matStack.stackSize < needed.stackSize)
 						{
 							drawItemStack(needed, k + slot.xDisplayPosition + CATALYST_X_OFFSET,
-								l + slot.yDisplayPosition, "" + needed.stackSize);
+								l + slot.yDisplayPosition, "" + (matStack == null ? needed.stackSize : needed.stackSize - matStack.stackSize));
 						}
 					}
 


### PR DESCRIPTION
Displays catalysts required as a count that decreases until requirement is met.

Old function was to stop displaying catalyst as soon as 1 item was provided.

Suggest re-working algorithm to require catalysts in correct spot.
This change doesn't work if catalysts are in weird spots and the helper images don't really make sense that way either.