### PR TITLE
Make knives throwable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /asm/*
 /bin/*
 /run/*
+/libs/
 /.settings/*
 *.psd
 *.iml

--- a/src/main/java/net/einsteinsci/betterbeginnings/ModMain.java
+++ b/src/main/java/net/einsteinsci/betterbeginnings/ModMain.java
@@ -76,6 +76,7 @@ public class ModMain
 
 		RegisterItems.register();
 		RegisterBlocks.register();
+		RegisterEntities.register();
 		RegisterTileEntities.register();
 	}
 

--- a/src/main/java/net/einsteinsci/betterbeginnings/client/RenderThrownKnife.java
+++ b/src/main/java/net/einsteinsci/betterbeginnings/client/RenderThrownKnife.java
@@ -1,0 +1,22 @@
+package net.einsteinsci.betterbeginnings.client;
+
+import net.einsteinsci.betterbeginnings.entity.projectile.EntityThrownKnife;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.entity.RenderSnowball;
+import net.minecraft.entity.Entity;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+
+public class RenderThrownKnife extends RenderSnowball 
+{	
+	public RenderThrownKnife(Minecraft minecraft) 
+	{
+		super(minecraft.getRenderManager(), Items.stick, minecraft.getRenderItem());
+	}
+	
+	@Override
+	public ItemStack func_177082_d(Entity entityIn) 
+	{
+		return ((EntityThrownKnife) entityIn).getKnife();
+	}
+}

--- a/src/main/java/net/einsteinsci/betterbeginnings/entity/projectile/EntityThrownKnife.java
+++ b/src/main/java/net/einsteinsci/betterbeginnings/entity/projectile/EntityThrownKnife.java
@@ -1,0 +1,164 @@
+package net.einsteinsci.betterbeginnings.entity.projectile;
+
+import io.netty.buffer.ByteBuf;
+import net.einsteinsci.betterbeginnings.items.ItemKnife;
+import net.einsteinsci.betterbeginnings.register.RegisterItems;
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.projectile.EntityThrowable;
+import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.ItemTool;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.potion.Potion;
+import net.minecraft.potion.PotionEffect;
+import net.minecraft.util.BlockPos;
+import net.minecraft.util.DamageSource;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumParticleTypes;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.network.ByteBufUtils;
+import net.minecraftforge.fml.common.registry.IEntityAdditionalSpawnData;
+
+public class EntityThrownKnife extends EntityThrowable implements IEntityAdditionalSpawnData
+{
+	private static final String TAG_THROWN_KNIFE = "ThrownKnife";
+
+	private ItemStack knife;
+	private float baseDamage;
+	private float force;
+	private boolean inTerrain;
+	private BlockPos stuckPos = new BlockPos(-1, -1, -1);
+
+	public EntityThrownKnife(World worldIn) 
+	{
+		super(worldIn);
+	}
+
+	public EntityThrownKnife(World world, EntityLivingBase thrower, ItemStack knife) 
+	{
+		super(world, thrower);
+		this.knife = knife;
+		this.baseDamage = ((ItemTool)knife.getItem()).getToolMaterial().getDamageVsEntity() + ItemKnife.DAMAGE;
+	}
+
+	@Override
+	protected void onImpact(MovingObjectPosition mop) 
+	{
+		switch(mop.typeOfHit)
+		{
+		case BLOCK:
+			if (!inTerrain)
+			{
+				doBlockHitEffects(worldObj, mop);
+			}
+			BlockPos pos = mop.getBlockPos();
+			IBlockState state = worldObj.getBlockState(pos);
+			if(state.getBlock().getCollisionBoundingBox(worldObj, pos, state) != null)
+			{
+				this.inTerrain = true;
+				this.stuckPos = pos;
+				this.setVelocity(0.0F, 0.0F, 0.0F);
+			}	
+			break;
+		case ENTITY:
+			if(mop.entityHit instanceof EntityLivingBase)
+			{
+				EntityLivingBase entityLiving = (EntityLivingBase) mop.entityHit;
+				if(!worldObj.isRemote && !knife.attemptDamageItem(2, rand))
+				{
+					entityLiving.attackEntityFrom(DamageSource.causeThrownDamage(mop.entityHit, this.getThrower()), baseDamage * force);
+					entityLiving.addPotionEffect(new PotionEffect(Potion.moveSlowdown.getId(), (int) (100 * force), 2, false, false));
+				}
+			}
+			break;
+		default:
+			break;
+		}
+	}
+
+	@Override
+	public void onCollideWithPlayer(EntityPlayer playerIn) 
+	{
+		this.knife.stackSize = 1;
+		if(inTerrain && playerIn.inventory.addItemStackToInventory(this.knife))
+		{
+			this.setDead();
+		}
+	}
+
+	@Override
+	public void onUpdate() 
+	{
+		if(worldObj.getBlockState(this.stuckPos).getBlock().isAir(worldObj, stuckPos))
+		{
+			this.inTerrain = false;
+		}
+		if(!inTerrain)
+		{
+			super.onUpdate();
+		}
+	}
+
+	private void doBlockHitEffects(World worldObj, MovingObjectPosition mop) 
+	{
+		IBlockState state = this.worldObj.getBlockState(mop.getBlockPos());
+		for(int p = 0; p < 8; p ++)
+		{
+			worldObj.spawnParticle(EnumParticleTypes.BLOCK_CRACK, this.posX, this.posY, this.posZ, 0.0F, 0.0F, 0.0F, Block.getStateId(state));
+		}
+		worldObj.playSoundAtEntity(this, state.getBlock().stepSound.getStepSound(), 0.8F, 0.9F);
+	}
+
+	@Override
+	public void readEntityFromNBT(NBTTagCompound tagCompound) 
+	{
+		super.readEntityFromNBT(tagCompound);
+		knife = ItemStack.loadItemStackFromNBT(tagCompound.getCompoundTag(TAG_THROWN_KNIFE));
+	}
+
+	@Override
+	public void writeEntityToNBT(NBTTagCompound tagCompound) 
+	{
+		super.writeEntityToNBT(tagCompound);
+		if(knife != null)
+		{
+			NBTTagCompound thrownKnife = knife.writeToNBT(new NBTTagCompound());
+			tagCompound.setTag(TAG_THROWN_KNIFE, thrownKnife);
+		}
+	}
+
+	public ItemStack getKnife() 
+	{
+		return knife;
+	}
+
+	public EntityThrownKnife setForce(float force)
+	{
+		this.force = force;
+		return this;
+	}
+
+	@Override
+	public void writeSpawnData(ByteBuf additionalData) 
+	{
+		ByteBufUtils.writeItemStack(additionalData, knife);
+		additionalData.writeFloat(baseDamage);
+		additionalData.writeFloat(force);
+	}
+
+	@Override
+	public void readSpawnData(ByteBuf additionalData) 
+	{
+		knife = ByteBufUtils.readItemStack(additionalData);
+		baseDamage = additionalData.readFloat();
+		force = additionalData.readFloat();
+	}
+}

--- a/src/main/java/net/einsteinsci/betterbeginnings/items/ItemKnife.java
+++ b/src/main/java/net/einsteinsci/betterbeginnings/items/ItemKnife.java
@@ -1,10 +1,15 @@
 package net.einsteinsci.betterbeginnings.items;
 
+import net.einsteinsci.betterbeginnings.entity.projectile.EntityThrownKnife;
 import net.einsteinsci.betterbeginnings.register.IBBName;
 import net.minecraft.block.Block;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
+import net.minecraft.item.EnumAction;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemTool;
+import net.minecraft.world.World;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -12,6 +17,7 @@ import java.util.Set;
 public abstract class ItemKnife extends ItemTool implements IBBName
 {
 	public static final float DAMAGE = 3.0f;
+	public static final int DRAW_TIME = 32;
 
 	public ItemKnife(ToolMaterial material)
 	{
@@ -43,6 +49,44 @@ public abstract class ItemKnife extends ItemTool implements IBBName
 		s.add(Blocks.cactus);
 
 		return s;
+	}
+	
+	@Override
+	public ItemStack onItemRightClick(ItemStack itemStackIn, World worldIn,
+			EntityPlayer playerIn) 
+	{
+		playerIn.setItemInUse(itemStackIn, this.getMaxItemUseDuration(itemStackIn));
+		return super.onItemRightClick(itemStackIn, worldIn, playerIn);
+	}
+	
+	@Override
+	public void onPlayerStoppedUsing(ItemStack stack, World worldIn,
+			EntityPlayer playerIn, int timeLeft) 
+	{
+		if(!worldIn.isRemote)
+		{
+			EntityThrownKnife knife = new EntityThrownKnife(worldIn, playerIn, stack);
+			knife.setForce((float) Math.min((this.getMaxItemUseDuration(stack) - timeLeft), ItemKnife.DRAW_TIME) / ItemKnife.DRAW_TIME);
+			System.out.println("SPAWN KNIFE");
+			worldIn.spawnEntityInWorld(knife);
+			if(!playerIn.capabilities.isCreativeMode)
+			{
+				playerIn.destroyCurrentEquippedItem();
+			}
+		}
+		
+	}
+	
+	@Override
+	public EnumAction getItemUseAction(ItemStack stack) 
+	{
+		return EnumAction.BOW;
+	}
+	
+	@Override
+	public int getMaxItemUseDuration(ItemStack stack) 
+	{
+		return 72000;
 	}
 
 	@Override

--- a/src/main/java/net/einsteinsci/betterbeginnings/network/ClientProxy.java
+++ b/src/main/java/net/einsteinsci/betterbeginnings/network/ClientProxy.java
@@ -3,16 +3,20 @@ package net.einsteinsci.betterbeginnings.network;
 import net.einsteinsci.betterbeginnings.ModMain;
 import net.einsteinsci.betterbeginnings.client.InfusionRender;
 import net.einsteinsci.betterbeginnings.client.RegisterMetaItemRenders;
+import net.einsteinsci.betterbeginnings.client.RenderThrownKnife;
+import net.einsteinsci.betterbeginnings.entity.projectile.EntityThrownKnife;
 import net.einsteinsci.betterbeginnings.gui.BBGuiHandler;
 import net.einsteinsci.betterbeginnings.tileentity.TileEntityInfusionRepair;
 import net.einsteinsci.betterbeginnings.util.LogUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
+import net.minecraftforge.fml.client.registry.RenderingRegistry;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
+
 import org.apache.logging.log4j.Level;
 
 public class ClientProxy extends ServerProxy
@@ -29,6 +33,7 @@ public class ClientProxy extends ServerProxy
 	{
 		super.init(e);
 		RegisterMetaItemRenders.init();
+		RenderingRegistry.registerEntityRenderingHandler(EntityThrownKnife.class, new RenderThrownKnife(Minecraft.getMinecraft()));
 	}
 
 	public void registerTileEntitySpecialRenderers()

--- a/src/main/java/net/einsteinsci/betterbeginnings/register/RegisterEntities.java
+++ b/src/main/java/net/einsteinsci/betterbeginnings/register/RegisterEntities.java
@@ -1,0 +1,19 @@
+package net.einsteinsci.betterbeginnings.register;
+
+import net.einsteinsci.betterbeginnings.ModMain;
+import net.einsteinsci.betterbeginnings.entity.projectile.EntityThrownKnife;
+import net.minecraft.entity.Entity;
+import net.minecraftforge.fml.common.registry.EntityRegistry;
+
+public class RegisterEntities 
+{
+	public static void register()
+	{
+		registerEntity(EntityThrownKnife.class, "thrownKnife", 0);
+	}
+	
+	private static void registerEntity(Class<? extends Entity> entityClass, String entityName, int id)
+	{
+		EntityRegistry.registerModEntity(entityClass, entityName, id, ModMain.modInstance, 80, 1, true);
+	}
+}


### PR DESCRIPTION
Thrown knives stick in blocks and will be picked up if the player collides with them. On hitting a block, the block's step sound is played and appropriate particles are spawned. On hitting an entity, the entity is damaged, given Slowness II and the knife receives 2 damage. The damage done is dependent on the knife thrown and the force it was thrown with. The duration of the Slowness effect ranges from 1-5 seconds, depending on the force the knife was thrown with. Force is the percentage of ItemKnife.DRAW_TIME the knife was drawn back for.
